### PR TITLE
Fix nodes to the left of a node being deleted being lost

### DIFF
--- a/test.ts
+++ b/test.ts
@@ -260,6 +260,22 @@ test('after one deletion', () => {
 
 
 // ----------------------------------------------------------------------------
+suite('non leaf deletion')
+
+test('root node', () => {
+  const rbt = fromObject({"a": true, "b": true, "c": true})
+  rbt.delete("b");
+  strictEqual(Array.from(rbt.entries()).length, 2)
+})
+
+test('non root, non leaf node', () => {
+  const rbt = fromObject({"a": true, "b": true, "c": true, "d": true, "e": true, "f": true})
+  rbt.delete("d");
+  strictEqual(Array.from(rbt.entries()).length, 5)
+})
+
+
+// ----------------------------------------------------------------------------
 suite('iteration')
 
 

--- a/tree.ts
+++ b/tree.ts
@@ -276,6 +276,7 @@ export class Tree<K = string, V = any>implements Map<K, V> {
     let child: Node<K, V>, parent: Node<K, V>, red: boolean
     if (node._left.ok && node._right.ok) {
       const next = this._firstNode(node._right)
+      next._left = node._left
       if (node === this._root) this._root = next
       else node === node._parent._left
         ? node._parent._left = next


### PR DESCRIPTION
Hi,

Thanks for writing this library! It saved me a lot of pain trying to write my own RB Tree :sweat_smile: 
This PR fixes a bug I've found where if you delete a node with children to its left they're lost.

i.e. currently if you have something like

```
    2
  /   \
 1     3
```

and delete `2`, `1` is lost because `3` does not get `_left` set
Hopefully the fix looks okay, I only have a pretty surface level understanding of the code!